### PR TITLE
fix openshift-client param type

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -29,4 +29,7 @@ spec:
       - build
     params:
     - name: ARGS
-      value: "rollout latest dumpy"
+      value:
+      - rollout
+      - latest
+      - dumpy


### PR DESCRIPTION
Following instructions from https://github.com/RedHatWorkshops/knative-on-ocp4/blob/master/2.BuildUsingOpenShiftPipelines.md

pipeline won't start

openshift-client Task accepts an ARGS param which should be an array, instead of a string (https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-client/openshift-client-task.yaml)